### PR TITLE
More dynamic support for gif duration and transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@
 
    This script will start an external ffmpeg to extract a section of the recorded video and export this as animated
    gif or mp4/webm video snippet.
+
+## [Requires FFmpeg and FFprobe](https://www.gyan.dev/ffmpeg/builds/ffmpeg-git-full.7z)
+
+
+[Thread](https://obsproject.com/forum/resources/animated-gif-creator.1589/
+)

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@
 ## [Requires FFmpeg and FFprobe](https://www.gyan.dev/ffmpeg/builds/ffmpeg-git-full.7z)
 
 
-[Thread](https://obsproject.com/forum/resources/animated-gif-creator.1589/
+[Original Thread + Tutorial](https://obsproject.com/forum/resources/animated-gif-creator.1589/
 )

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
    This script will start an external ffmpeg to extract a section of the recorded video and export this as animated
    gif or mp4/webm video snippet.
 
+2. If you want to create a gif with alpha channels/transparency, set these settings in OBS ![image](https://github.com/g-l-i-t-c-h-o-r-s-e/obs-lua-scripts/assets/17163949/b5e5d534-d6fe-4688-93c5-becc54bc4ab9)
+
+
 ## [Requires FFmpeg and FFprobe](https://www.gyan.dev/ffmpeg/builds/ffmpeg-git-full.7z)
 
 

--- a/postprocess-from-obs.cmd
+++ b/postprocess-from-obs.cmd
@@ -176,7 +176,7 @@ REM build ffmpeg commandline and call it
     REM build palette filter option for gif images
     REM "dither=none" will produce slight color distortion but avoid dithering pixelation.
     REM Use "dither=sierra2_4a" for standard ffmpeg dithering.
-    if "%ext%"=="gif" set filt_palette=,split[s0][s1];[s0]palettegen=max_colors=%colors%:reserve_transparent=0[p];[s1][p]paletteuse=dither=none:diff_mode=rectangle
+    if "%ext%"=="gif" set filt_palette=,split[s0][s1];[s0]palettegen=max_colors=%colors%:reserve_transparent=1[p];[s1][p]paletteuse=dither=none:diff_mode=rectangle:alpha_threshold=128
 
     REM build fps input filter option
     REM don't ask me why setpts=PTS-1 makes the fps filter not produce stutter


### PR DESCRIPTION
I've slightly modified this to allow you to use any gifs duration, as the video_length variable now. This allows you to take any gif as a base, add effects/other gifs to it and export it without altering the base gifs duration; while preserving alpha channels/transparency. The alpha is preserved by encoding into an mkv with the png video codec. 
Everything appears to be functioning well, lmk if I need to clarify anything (:

This was what I was trying to achieve in these posts here:
https://obsproject.com/forum/threads/animated-gif-creator.159107/post-601018
https://obsproject.com/forum/threads/animated-gif-creator.159107/post-601037